### PR TITLE
Stack tracing & Finalizing added

### DIFF
--- a/depends/Combiner.lua
+++ b/depends/Combiner.lua
@@ -22,16 +22,66 @@ end]]):gsub("[\t ]+", " ")
 -- @tparam boolean verify Verify the source files before loading
 -- @see Depends.Dependencies
 function Depends.Dependencies:Combiner(outputFile, header, verify)
+	local line = 2
+	local oldLine = 2
+	local linetomodule = {}
+	local modulestarts = {}
+	
+	local function getLines(str)
+		local x, a, b = 1;
+		local c = 1
+		while x < string.len(str) do
+			a, b = string.find(str, '.-\n', x);
+			if not a then
+				break;
+			else
+				c = c +1
+			end;
+			x = b + 1;
+		end
+		return c
+	end
+	local function setLines(mod, n1, n2)
+		if not n1 and not n2 then return end
+		
+		if modulestarts[mod] then
+			modulestarts[mod] = math.min(n1, modulestarts[mod])
+		else
+			modulestarts[mod] = n1
+		end
+		
+		local min
+		if n1 and not n2 then
+			min = n1
+		elseif not n1 and n2 then
+			min = n2
+		elseif n1 and n2 then
+			min = math.min(n1, n2)
+		end
+		
+		linetomodule[min] = mod
+	end
+	
 	local path = self.path
 	local shouldExport = self.shouldExport
 	local loadstring = loadstring
-
+	
 	local output = fs.open(fs.combine(HowlFile.CurrentDirectory, outputFile), "w")
 	assert(output, "Could not create" .. outputFile)
+	
+	function writeLine(txt, mod)
+		output.writeLine(txt)
+		oldLine = line
+		line = line + getLines(txt)
+		setLines(mod or "Unknown", oldLine +1, line -1)
+	end
 
 	-- If header == nil or header is true then include the header
-	if header ~= false then output.writeLine(functionLoader) end
-
+	output.writeLine("local __program = function(...)")
+	
+	if header ~= false then writeLine(functionLoader, "file") end
+	
+	
 	local exports = {}
 	for file in self:Iterate() do
 		local filePath = file.path
@@ -50,12 +100,13 @@ function Depends.Dependencies:Combiner(outputFile, header, verify)
 				error(msg)
 			end
 		end
-
+		
+		local beginline = 
 		Utils.Verbose("Adding " .. filePath)
 
 		local moduleName = file.name
 		if file.__isMain then -- If the file is a main file then just print it
-			output.writeLine(contents)
+			writeLine(contents, file.alias or file.path)
 
 		elseif moduleName then -- If the file has an module name then use that
 			-- Check if we are prevented in setting a custom environment
@@ -72,27 +123,100 @@ function Depends.Dependencies:Combiner(outputFile, header, verify)
 				line = "local " .. line
 			end
 
-			output.writeLine(line)
-			output.writeLine(contents)
-			output.writeLine(endFunc)
+			writeLine(line, "file")
+			writeLine(contents, moduleName)
+			writeLine(endFunc, "file")
 
 		else -- We have no name so we can just export it normally
 			local noWrap = file.noWrap -- Don't wrap in do...end if noWrap is set
 
-			if noWrap then output.writeLine("do") end
-			output.writeLine(contents)
-			if noWrap then output.writeLine('end') end
+			if noWrap then writeLine("do", "file") end
+			writeLine(contents, file.alias or file.path)
+			if noWrap then writeLine("end", "file") end
 		end
 	end
-
+	
+	local finalizertxt = ""
+	if self.finalizer then
+		local r = fs.open(fs.combine(path, self.finalizer.path), "r")
+		assert(r, "Could not open "..fs.combine(path, self.finalizer.path))
+		finalizertxt = r.readAll() or ""
+	end
 	-- Should we export any values?
 	if shouldExport then
-		output.writeLine("return {")
+		writeLine("return {", "file")
 		for _, export in ipairs(exports) do
-			output.writeLine("\t" .. export .. "=" .. export ..",")
+			writeLine("\t" .. export .. "=" .. export ..",", "file")
 		end
-		output.writeLine("}")
+		writeLine("}", "file")
 	end
+	output.writeLine(
+[[
+end
+local __finalizer = function() ]]..finalizertxt..[[ end 
+local __linetomodule = setmetatable(]]..textutils.serialize(linetomodule)..[[, {__index = function(t, k) if k > 1 then return t[k-1] end end})
+local __modulestarts = ]]..textutils.serialize(modulestarts)..[[ 
+local __programend = ]]..line..[[ 
+local firstfilename = nil
+local function __updateerr(__err)
+	local __t = string.find(__err, ":")
+	if not __t then return __err end
+	local __filename = __err:sub(1, __t -1)
+	if not firstfilename then
+		firstfilename = __err:sub(1, __t-1)
+	end
+	if __filename ~= firstfilename then
+		return __err
+	end
+	local __t2 = string.find(string.sub(__err, __t +1, -1), ":")
+	if not __t2 then return __err end
+	local __errline = tonumber(string.sub(__err, __t +1, __t + __t2 -1))
+	
+	if __errline then
+		-- convert to module lines
+		if __errline >= __programend then
+			return nil
+		end
+		local __modname = __linetomodule[__errline] or "unknown"
+		local __modline = __errline - __modulestarts[__modname] or -1
+		return __modname..":"..__modline..":"..tostring(__err:sub(__t + __t2 +1, -1))
+		
+	end
+end
+local __varargs = {...}
+local __returns = {}
+local __current = term.current()
+local __ok, __err = xpcall(function() __returns = {__program(unpack(__varargs))} end, 
+function(msg) pcall(function() (function(__msg)
+	__msg = "  "..(__updateerr(__msg) or "")
+	for i = 8, 7 + 18 do
+		local _, err = pcall(function() error("", i) end)
+		err = __updateerr(err)
+		if not err then break end
+		__msg = __msg .. "\n  " .. err
+	end
+
+	err = __msg
+	local finmsg
+	local ok, _err = pcall(function() finmsg = __finalizer() end)
+	term.redirect(__current)
+	term.setBackgroundColor(colors.black)
+	term.setTextColor(colors.red)
+	term.clear()
+	term.setCursorPos(1, 1)
+	if not ok then
+		print("Finalizer Error: ", _err)
+	end
+	if finmsg then
+		print(finmsg)
+	end
+	print("Raw Stack Trace: \n", err)
+	return err
+end)(msg) end) end)
+if __ok then
+	return unpack(__returns)
+end
+]])
 	output.close()
 end
 

--- a/depends/Combiner.lua
+++ b/depends/Combiner.lua
@@ -9,7 +9,7 @@ local functionLoaderName = "_W"
 	This probably need some work as a function but...
 ]]
 local functionLoader = ("local function " .. functionLoaderName .. [[(f)
-	local e=setmetatable({}, {__index = getfenv(), __newindex = function(t, k, v) (getfenv())[k] = v end})
+	local e=setmetatable({}, {__index = getfenv()})
 	setfenv(f,e)
 	local r=f()
 	if r ~= nil then return r end

--- a/depends/Combiner.lua
+++ b/depends/Combiner.lua
@@ -9,7 +9,7 @@ local functionLoaderName = "_W"
 	This probably need some work as a function but...
 ]]
 local functionLoader = ("local function " .. functionLoaderName .. [[(f)
-	local e=setmetatable({}, {__index = getfenv()})
+	local e=setmetatable({}, {__index = getfenv(), __newindex = function(t, k, v) (getfenv())[k] = v end})
 	setfenv(f,e)
 	local r=f()
 	if r ~= nil then return r end

--- a/depends/Depends.lua
+++ b/depends/Depends.lua
@@ -101,11 +101,18 @@ function Dependencies:File(path)
 		shouldExport = true,
 		noWrap = false,
 		__isMain = false,
+		__isFinalizer = false,
 		parent = self,
 	}, {__index = File})
 
 	self.files[path] = file
 	return file
+end
+
+function Dependencies:Finalizer(path)
+	local file = self:FindFile(path) or self:File(path)
+	file.__isFinalizer = true
+	self.finalizer = file
 end
 
 --- Add a 'main' file to the dependency list. This is a file that will be executed (added to the end of a script)


### PR DESCRIPTION
If your program crashes, an error handler will print out the stack trace and call a finalizer function which should close file handles (for example).

You can set your finalizing function/file like this: just call `:Finalizer "path/to/finalizer.lua"` on your Dependencies instance. It will be looking something like this: `sources:Finalizer "path/to/finalizer.lua"`.

Notice: The finalizer is not included in the program environment, so it can't access the program locals.
Your finalizer can return a string, which is printed before the stack trace.
(You can't print things to terminal in the finalizer, because the terminal's cleaned after the finalizer is called.)