### PR TITLE
Fix typo

### DIFF
--- a/.build.lua
+++ b/.build.lua
@@ -9,7 +9,7 @@ handle.close()
 
 local func, msg = loadfile("bootstrap.lua", _ENV)
 if not func then
-	howlci.status("fail", "Cannot load boostrapper: " .. (msg or "<no msg>"))
+	howlci.status("fail", "Cannot load bootstrapper: " .. (msg or "<no msg>"))
 	return
 end
 


### PR DESCRIPTION
In .build.lua, it should say "Cannot load bootstrapper" instead of "Cannot load boostrapper".

What is a boost rapper anyways? Is it Sonic rapping while boosting? (/s)