### PR TITLE
Display percent size reduction for minify tasks and use basename of running program in CLI

### DIFF
--- a/howl/cli.lua
+++ b/howl/cli.lua
@@ -70,7 +70,7 @@ if not howlFile then
 		colored.printColor("orange", "\nOptions:")
 		options:Help("  ")
 	elseif #taskList == 0 then
-		error(currentDirectory .. " Use " .. shell.getRunningProgram() .. " --help to dislay usage.", 0)
+		error(currentDirectory .. " Use " .. fs.getName(shell.getRunningProgram()) .. " --help to dislay usage.", 0)
 	else
 		error(currentDirectory, 0)
 	end

--- a/howl/cli.lua
+++ b/howl/cli.lua
@@ -7,7 +7,7 @@ local fs = require "howl.platform".fs
 
 local howlFile, currentDirectory = loader.FindHowl()
 -- TODO: Don't pass the error message as the current directory: construct mediator/arg parser another time.
-local context = require "howl.context"(currentDirectory or shell.dir(), {...})
+local context = require "howl.context"(currentDirectory or fs.currentDir(), {...})
 
 local options = context.arguments
 
@@ -63,14 +63,17 @@ if not howlFile then
 			Then you need to define some tasks. Maybe something like this:
 		]]):gsub("\t", ""):gsub("\n+$", "")))
 
-		colored.printColor("magenta", 'Tasks:minify("minify", "file.lua", "file.min.lua")')
+		colored.printColor("magenta", 'Tasks:minify "minify" {')
+		colored.printColor("magenta", '  input = "build/Howl.lua",')
+		colored.printColor("magenta", '  output = "build/Howl.min.lua",')
+		colored.printColor("magenta", '}')
 
-		colored.printColor("white", "Now just run '" .. shell.getRunningProgram() .. " minify'!")
+		colored.printColor("white", "Now just run '" .. fs.getName(fs.currentProgram()) .. " minify'!")
 
 		colored.printColor("orange", "\nOptions:")
 		options:Help("  ")
 	elseif #taskList == 0 then
-		error(currentDirectory .. " Use " .. fs.getName(shell.getRunningProgram()) .. " --help to dislay usage.", 0)
+		error(currentDirectory .. " Use " .. fs.getName(fs.currentProgram()) .. " --help to dislay usage.", 0)
 	else
 		error(currentDirectory, 0)
 	end

--- a/howl/lexer/rebuild.lua
+++ b/howl/lexer/rebuild.lua
@@ -377,11 +377,11 @@ end
 local function minifyFile(cd, inputFile, outputFile)
 	outputFile = outputFile or inputFile
 
-	local contents = platform.fs.read(platform.fs.combine(cd, inputFile))
+	local oldContents = platform.fs.read(platform.fs.combine(cd, inputFile))
+	local newContents = minifyString(oldContents)
 
-	contents = minifyString(contents)
-
-	platform.fs.write(platform.fs.combine(cd, outputFile), contents)
+	platform.fs.write(platform.fs.combine(cd, outputFile), newContents)
+	return #oldContents, #newContents
 end
 
 --- @export

--- a/howl/modules/tasks/minify.lua
+++ b/howl/modules/tasks/minify.lua
@@ -52,6 +52,11 @@ end
 
 function MinifyTask:runAction(context)
 	minifyFile(context.root, self.options.input, self.options.output)
+	local oldSize = fs.getSize(self.options.input)
+	local newSize = fs.getSize(self.options.output)
+	local percentDecreased = (oldSize-newSize)/oldSize
+	percentDecreased = percentDecreased * 100
+	context.env.logger:verbose("%.0f%% decrease in file size",percentDecreased)
 end
 
 local MinifyExtensions = {}

--- a/howl/modules/tasks/minify.lua
+++ b/howl/modules/tasks/minify.lua
@@ -51,12 +51,12 @@ function MinifyTask:setup(context, runner)
 end
 
 function MinifyTask:runAction(context)
-	minifyFile(context.root, self.options.input, self.options.output)
-	local oldSize = fs.getSize(self.options.input)
-	local newSize = fs.getSize(self.options.output)
-	local percentDecreased = (oldSize-newSize)/oldSize
-	percentDecreased = percentDecreased * 100
-	context.env.logger:verbose("%.0f%% decrease in file size",percentDecreased)
+	local oldSize, newSize = minifyFile(context.root, self.options.input, self.options.output)
+	local percentDecreased = (oldSize - newSize) / oldSize * 100
+
+	-- Ugly hack as length specifiers don't work on %f under LuaJ.
+	percentDecreased = math.floor(percentDecreased * 100) / 100
+	context.logger:verbose(("%.20f%% decrease in file size"):format(percentDecreased))
 end
 
 local MinifyExtensions = {}

--- a/howl/platform/cc.lua
+++ b/howl/platform/cc.lua
@@ -136,6 +136,7 @@ return {
 		getDir = fs.getDir,
 		getName = fs.getName,
 		currentDir = shell.dir,
+		currentProgram = shell.getRunningProgram,
 
 		-- File access
 		read = read,

--- a/howl/platform/cc.lua
+++ b/howl/platform/cc.lua
@@ -142,6 +142,7 @@ return {
 		write = write,
 		readDir = readDir,
 		writeDir = writeDir,
+		getSize = fs.getSize,
 
 		-- Type checking
 		assertExists = assertExists,

--- a/howl/platform/native.lua
+++ b/howl/platform/native.lua
@@ -40,6 +40,12 @@ return {
 		write = file.write,
 		readDir = notImplemented("fs.readDir"),
 		writeDir = notImplemented("fs.writeDir"),
+		getSize = function(n)
+			local file = io:open(n,"r")
+			local size = file:seek("end")
+			file:close()
+			return size
+		end,
 
 		assertExists = function(file)
 			if not path.exists(file) then

--- a/howl/tasks/Task.lua
+++ b/howl/tasks/Task.lua
@@ -168,6 +168,18 @@ function Task:Run(context, ...)
 
 	if s then
 		context.env.logger:success("%s finished", self.name)
+		if self.description=="Minify a file" then
+			--For minify tasks, show reduction percent
+			local oldFile = io:open(self.options.input,"r")
+			local newFile = io:open(self.options.output,"r")
+			local oldSize = oldFile:seek("end")
+			local newSize = newFile:seek("end")
+			oldFile:close()
+			newFile:close()
+			local percentDecreased = (oldSize-newSize)/oldSize
+			percentDecreased = percentDecreased * 100
+			context.env.logger:info("%s%% decrease in file size",string.format("%.0f",percentDecreased))
+		end
 	else
 		context.env.logger:error("%s: %s", self.name, err or "no message")
 		error("Error running tasks", 0)

--- a/howl/tasks/Task.lua
+++ b/howl/tasks/Task.lua
@@ -5,7 +5,9 @@ local assert = require "howl.lib.assert"
 local class = require "howl.class"
 local colored = require "howl.lib.colored"
 local mixin = require "howl.class.mixin"
-local os = require "howl.platform".os
+local platform = require "howl.platform"
+local os = platform.os
+local fs = platform.fs
 local utils = require "howl.lib.utils"
 
 local insert = table.insert
@@ -170,15 +172,13 @@ function Task:Run(context, ...)
 		context.env.logger:success("%s finished", self.name)
 		if self.description=="Minify a file" then
 			--For minify tasks, show reduction percent
-			local oldFile = io:open(self.options.input,"r")
-			local newFile = io:open(self.options.output,"r")
-			local oldSize = oldFile:seek("end")
-			local newSize = newFile:seek("end")
+			local oldSize = fs.getSize()
+			local newSize = fs.getSize()
 			oldFile:close()
 			newFile:close()
 			local percentDecreased = (oldSize-newSize)/oldSize
 			percentDecreased = percentDecreased * 100
-			context.env.logger:info("%s%% decrease in file size",string.format("%.0f",percentDecreased))
+			context.env.logger:verbose("%.0f%% decrease in file size",percentDecreased)
 		end
 	else
 		context.env.logger:error("%s: %s", self.name, err or "no message")

--- a/howl/tasks/Task.lua
+++ b/howl/tasks/Task.lua
@@ -5,9 +5,7 @@ local assert = require "howl.lib.assert"
 local class = require "howl.class"
 local colored = require "howl.lib.colored"
 local mixin = require "howl.class.mixin"
-local platform = require "howl.platform"
-local os = platform.os
-local fs = platform.fs
+local os = require "howl.platform".os
 local utils = require "howl.lib.utils"
 
 local insert = table.insert
@@ -170,16 +168,6 @@ function Task:Run(context, ...)
 
 	if s then
 		context.env.logger:success("%s finished", self.name)
-		if self.description=="Minify a file" then
-			--For minify tasks, show reduction percent
-			local oldSize = fs.getSize()
-			local newSize = fs.getSize()
-			oldFile:close()
-			newFile:close()
-			local percentDecreased = (oldSize-newSize)/oldSize
-			percentDecreased = percentDecreased * 100
-			context.env.logger:verbose("%.0f%% decrease in file size",percentDecreased)
-		end
 	else
 		context.env.logger:error("%s: %s", self.name, err or "no message")
 		error("Error running tasks", 0)


### PR DESCRIPTION
For minify tasks, this PR shows percent decrease in size due to minification. This is a statistic that can easily be ignored but would be nice for some projects just to know how much the minifier helps without needing to do the math.

This PR also makes it so that the part of the "no Howlfile" message that says to run Howl --help now takes the base name of the program (i.e; "howl --help" instead of "bin/howl --help")